### PR TITLE
Add mergify configuration from retest/recheck

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,35 @@
+pull_request_rules:
+  - name: "rebase unreviewed non-release PRs"
+    conditions:
+      - "head~=^(?!(release|hotfix)).*$"
+      - "#approved-reviews-by=0"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      rebase: {}
+
+  - name: "merge non-release PRs with strict rebase"
+    conditions:
+      - "head~=^(?!(release|hotfix)).*$"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      merge:
+        strict: true
+        strict_method: rebase
+        method: merge
+
+  - name: "merge release PRs with strict merge"
+    conditions:
+      - "head~=^(release|hotfix).*$"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      merge:
+        strict: true
+        method: merge
+
+  - name: "delete PR branches after merge"
+    conditions:
+      - merged
+    actions:
+      delete_head_branch: {}


### PR DESCRIPTION
This switches from rebazer to mergify to retest/recheck.

Please do the following:

1. Disable rebazer.
2. Verify branch protection rules in place.
3. Mark this PR ready for review.
4. Review this PR.
5. Manually merge.