### PR TITLE
Do not throw exception if lifecycle is null

### DIFF
--- a/src/main/java/de/retest/recheck/junit/vintage/RecheckRule.java
+++ b/src/main/java/de/retest/recheck/junit/vintage/RecheckRule.java
@@ -74,10 +74,9 @@ public class RecheckRule implements TestRule {
 	}
 
 	private void before( final String testName ) {
-		if ( recheckLifecycle == null ) {
-			throw new NullPointerException( NPE_EXCEPTION_MESSAGE );
+		if ( recheckLifecycle != null ) {
+			recheckLifecycle.startTest( testName );
 		}
-		recheckLifecycle.startTest( testName );
 	}
 
 	private void after() {


### PR DESCRIPTION
since the `@Before`-method has not been called yet.

This seems to be caused by the junit-4 extension mechanisms where there is no real before method to call and was introduced with the refactoring of #26.

Failing test: https://travis-ci.com/github/retest/recheck-web/builds/165963389
Succeeded test (with this commit): https://travis-ci.com/github/retest/recheck-web/builds/165978949

While I never looked into the extension mechanism, I do not think that there is really something we can do about that.